### PR TITLE
feat: add `output_language` config attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,35 @@ Each preset also supports an optional `output_mode`, which defines how the comma
 
 If not specified, both `input_mode` and `output_mode` default to `stdin` and `replace`, respectively.
 
+#### Updating the output block language
+
+Presets in `replace` mode can also update the Markdown code block language by setting `output_language`:
+
+```toml
+[presets.nixtojson]
+language = "nixToJson"
+command = ["nix", "eval", "--json", "--file", "{file}"]
+input_mode = "file"
+output_mode = "replace"
+output_language = "json"
+```
+
+This lets a generated block change from:
+
+````
+```nixToJson
+{ enabled = true; }
+```
+````
+
+to:
+
+````
+```json
+{"enabled":true}
+```
+````
+
 ## Markdown Syntax
 
 The tool scans for fenced code blocks like:

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub struct PresetConfig {
     pub input_mode: InputMode,
     #[serde(default)]
     pub output_mode: OutputMode,
+    #[serde(default)]
+    pub output_language: Option<String>,
 }
 
 fn deserialize_string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -240,7 +240,11 @@ fn handle_preset_result(
     match preset_cfg.output_mode {
         OutputMode::Check => Ok(None),
         OutputMode::Replace => {
-            let mismatch = String::from_utf8_lossy(&output.stdout).trim() != block.source().trim();
+            let command_output = String::from_utf8_lossy(&output.stdout);
+            let replacement_info_string =
+                replacement_info_string(block.info_string(), preset_cfg.output_language.as_deref());
+            let mismatch = command_output.trim() != block.source().trim()
+                || replacement_info_string != block.info_string();
 
             if !mismatch {
                 debug!(
@@ -269,13 +273,8 @@ fn handle_preset_result(
                 block.path.display()
             );
 
-            let updated_code = std::iter::once(format!("```{}", block.info_string()))
-                .chain(
-                    String::from_utf8_lossy(&output.stdout)
-                        .trim()
-                        .lines()
-                        .map(|l| l.to_string()),
-                )
+            let updated_code = std::iter::once(format!("```{replacement_info_string}"))
+                .chain(command_output.trim().lines().map(|l| l.to_string()))
                 .chain(std::iter::once("```".to_string()))
                 .map(|l| {
                     format!("{:indent$}{}", "", l, indent = block.indent())
@@ -288,4 +287,18 @@ fn handle_preset_result(
             Ok(Some(block.with_updated_code(updated_code)))
         }
     }
+}
+
+fn replacement_info_string(original: &str, output_language: Option<&str>) -> String {
+    let Some(output_language) = output_language.map(str::trim).filter(|s| !s.is_empty()) else {
+        return original.to_string();
+    };
+
+    let original = original.trim_start();
+    let suffix = original
+        .find(char::is_whitespace)
+        .map(|index| &original[index..])
+        .unwrap_or_default();
+
+    format!("{output_language}{suffix}")
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -495,6 +495,95 @@ echo lang2
 }
 
 #[test]
+fn test_output_language_rewrites_code_block_language() {
+    let env = TestEnv::from_raw_markdown(
+        r#"
+```nixToJson
+{ enabled = true; name = "hello"; }
+```
+        "#,
+        r#"
+        [presets.nixtojson]
+        language = "nixToJson"
+        command = ["printf", "{\"enabled\":true,\"name\":\"hello\"}"]
+        input_mode = "stdin"
+        output_mode = "replace"
+        output_language = "json"
+        "#,
+    );
+
+    let output = env.run(&[
+        env.md_path.to_str().unwrap(),
+        "--config",
+        env.cfg_path.to_str().unwrap(),
+    ]);
+
+    assert!(output.status.success());
+    let updated = std::fs::read_to_string(&env.md_path).unwrap();
+    assert!(updated.contains("```json\n{\"enabled\":true,\"name\":\"hello\"}\n```"));
+    assert!(!updated.contains("```nixToJson"));
+}
+
+#[test]
+fn test_output_language_preserves_info_string_attributes() {
+    let env = TestEnv::from_raw_markdown(
+        r#"
+```nixToJson title="flake output"
+{}
+```
+        "#,
+        r#"
+        [presets.nixtojson]
+        language = "nixToJson"
+        command = ["printf", "{}"]
+        input_mode = "stdin"
+        output_mode = "replace"
+        output_language = "json"
+        "#,
+    );
+
+    let output = env.run(&[
+        env.md_path.to_str().unwrap(),
+        "--config",
+        env.cfg_path.to_str().unwrap(),
+    ]);
+
+    assert!(output.status.success());
+    let updated = std::fs::read_to_string(&env.md_path).unwrap();
+    assert!(updated.contains("```json title=\"flake output\"\n{}\n```"));
+}
+
+#[test]
+fn test_check_mode_detects_output_language_only_mismatch() {
+    let env = TestEnv::from_raw_markdown(
+        r#"
+```nixToJson
+{}
+```
+        "#,
+        r#"
+        [presets.nixtojson]
+        language = "nixToJson"
+        command = ["printf", "{}"]
+        input_mode = "stdin"
+        output_mode = "replace"
+        output_language = "json"
+        "#,
+    );
+
+    let output = env.run(&[
+        env.md_path.to_str().unwrap(),
+        "--check",
+        "--config",
+        env.cfg_path.to_str().unwrap(),
+    ]);
+
+    assert!(!output.status.success());
+    let after = std::fs::read_to_string(&env.md_path).unwrap();
+    assert!(after.contains("```nixToJson\n{}\n```"));
+}
+
+#[test]
 fn test_legacy_language_field() {
     let env = TestEnv::from_raw_markdown(
         r#"


### PR DESCRIPTION
This PR

- [x] implements a new feature

Fixes https://github.com/drupol/markdown-code-runner/issues/17.
