### PR TITLE
fix: preserve child status after broken pipe

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,6 @@
 use log::debug;
 use std::fs;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 use tempfile::NamedTempFile;
@@ -33,7 +33,13 @@ fn run_command_with_stdin(
 
     let mut child = cmd.spawn()?;
     if let Some(stdin) = child.stdin.as_mut() {
-        stdin.write_all(input.as_bytes())?;
+        match stdin.write_all(input.as_bytes()) {
+            Ok(()) => {}
+            // The child may exit without reading stdin. Preserve its exit
+            // status instead of replacing it with a broken-pipe error.
+            Err(error) if error.kind() == ErrorKind::BrokenPipe => {}
+            Err(error) => return Err(error.into()),
+        }
     }
 
     let output = child.wait_with_output()?;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -114,8 +114,10 @@ fn test_check_mode_detects_differences() {
 
 #[test]
 fn test_prints_warning_on_failure() {
+    // Exceed pipe capacity so that child closes stdin before we write last byte.
+    let markdown = "echo bad\n".repeat(128 * 1024);
     let env = TestEnv::new(
-        "echo bad",
+        &markdown,
         "sh",
         r#"
         [presets.bad-sh]


### PR DESCRIPTION
If the child exits before we write the last byte to its stdin, write
fails with a broken-pipe error. This results in a failure to harvest the
child's exit code.

This scenario broke nixpkgs lint job at least once because
test_prints_warning_on_failure failed, see:

https://github.com/NixOS/nixpkgs/actions/runs/29976143242/job/89108239643?pr=544752

The fix is to ignore broken-pipe errors. Also, the test case is updated
to force the error to confirm the fix.
